### PR TITLE
feat: Add forward_chunk method to ConformerEncoder and enhance unit t…

### DIFF
--- a/python/oasr/models/conformer/model.py
+++ b/python/oasr/models/conformer/model.py
@@ -58,7 +58,7 @@ class GlobalCMVN(nn.Module):
 
 
 class CTC(torch.nn.Module):
-    """CTC module"""
+    """CTC module: Linear -> log_softmax"""
 
     def __init__(
         self,
@@ -88,7 +88,7 @@ class CTC(torch.nn.Module):
 
 
 class PositionwiseFeedForward(nn.Module):
-    """Position-wise feed-forward: Linear -> activation -> Linear (WeNet)."""
+    """Position-wise feed-forward module: Linear -> activation -> Linear (WeNet)."""
 
     def __init__(
         self,
@@ -113,7 +113,7 @@ class PositionwiseFeedForward(nn.Module):
 
 
 class ConvolutionModule(nn.Module):
-    """Conformer conv: pointwise -> GLU -> depthwise -> norm -> activation -> pointwise (WeNet)."""
+    """Convolution module: pointwise -> GLU -> depthwise -> norm -> activation -> pointwise (WeNet)."""
 
     def __init__(
         self,
@@ -204,7 +204,7 @@ class ConvolutionModule(nn.Module):
 
 
 class RelPositionalEncoding(nn.Module):
-    """Relative positional encoding for Conformer (WeNet). Returns (x * xscale, pos_emb)."""
+    """Relative positional encoding module (WeNet). Returns (x * xscale, pos_emb)."""
 
     def __init__(self, d_model: int, max_len: int = 5000):
         super().__init__()
@@ -245,7 +245,7 @@ class RelPositionalEncoding(nn.Module):
 
 
 class Conv2dSubsampling(nn.Module):
-    """Conv2d subsampling (e.g. 4x) + linear + positional encoding (WeNet Conv2dSubsampling4)."""
+    """Conv2d subsampling module (e.g. 4x) + linear + positional encoding (WeNet Conv2dSubsampling4)."""
 
     def __init__(
         self,
@@ -303,7 +303,7 @@ class Conv2dSubsampling(nn.Module):
 
 
 class ConformerEncoderLayer(nn.Module):
-    """Single Conformer block: macaron FFN -> MHA (rel_pos) -> conv -> FFN (WeNet)."""
+    """Conformer encoder layer: macaron FFN -> MHA (rel_pos) -> conv -> FFN (WeNet)."""
 
     def __init__(
         self,
@@ -399,10 +399,6 @@ class ConformerEncoderLayer(nn.Module):
                               torch.zeros(0, 0, 0, 0)),
         cnn_cache: torch.Tensor = torch.zeros(0, 0, 0),
     ) -> Tuple[torch.Tensor, torch.Tensor, T_CACHE, torch.Tensor]:
-        # Attention always uses SDPA-based kernels. WeNet expects the
-        # attention mask to be an additive bias (float/bfloat16/half), not a
-        # bool tensor, so convert boolean masks to a large negative bias via
-
         if self.feed_forward_macaron is not None:
             residual = x
             if self.normalize_before:
@@ -444,7 +440,7 @@ class ConformerEncoderLayer(nn.Module):
 
 
 class ConformerEncoder(nn.Module):
-    """Conformer encoder: subsampling + pos enc + N x ConformerEncoderLayer + final norm."""
+    """Conformer encoder module."""
 
     def __init__(
         self,
@@ -507,13 +503,164 @@ class ConformerEncoder(nn.Module):
             xs = self.after_norm(xs)
         return xs, masks
 
+    def forward_chunk(
+        self,
+        xs: torch.Tensor,
+        offset: int,
+        required_cache_size: int,
+        att_cache: torch.Tensor = torch.zeros(0, 0, 0, 0),
+        cnn_cache: torch.Tensor = torch.zeros(0, 0, 0, 0),
+        att_mask: torch.Tensor = torch.zeros((0, 0, 0)),
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """ Forward just one chunk
 
-# -----------------------------------------------------------------------------
-# Top-level model
-# -----------------------------------------------------------------------------
+        Args:
+            xs (torch.Tensor): chunk input, with shape (b=1, time, mel-dim),
+                where `time == (chunk_size - 1) * subsample_rate + \
+                        subsample.right_context + 1`
+            offset (int): current offset in encoder output time stamp
+            required_cache_size (int): cache size required for next chunk
+                compuation
+                >=0: actual cache size
+                <0: means all history cache is required
+            att_cache (torch.Tensor): cache tensor for KEY & VALUE in
+                transformer/conformer attention, with shape
+                (elayers, head, cache_t1, d_k * 2), where
+                `head * d_k == hidden-dim` and
+                `cache_t1 == chunk_size * num_decoding_left_chunks`.
+            cnn_cache (torch.Tensor): cache tensor for cnn_module in conformer,
+                shape (elayers, b=1, cache_t2, hidden-dim), where
+                `cache_t2 == cnn.lorder`; per-layer layout is (B, T, C).
+            att_mask (torch.Tensor): additive attention bias (float dtype), shape
+                (1, chunk_size, attention_key_size) with attention_key_size =
+                cache_t1 + chunk_size. Use zeros for no masking. Empty placeholder
+                (0,0,0) is replaced internally by a zero mask when chunk_size > 0.
+
+        Returns:
+            torch.Tensor: output of current input xs,
+                with shape (b=1, chunk_size, hidden-dim).
+            torch.Tensor: new attention cache required for next chunk, with
+                dynamic shape (elayers, head, ?, d_k * 2)
+                depending on required_cache_size.
+            torch.Tensor: new conformer cnn cache required for next chunk, shape
+                (elayers, 1, cache_t2, hidden-dim), same as input cnn_cache.
+
+        """
+        assert xs.size(0) == 1
+        # tmp_masks is just for interface compatibility
+        tmp_masks = torch.ones(1,
+                               xs.size(1),
+                               device=xs.device,
+                               dtype=torch.bool)
+        tmp_masks = tmp_masks.unsqueeze(1)
+        if self.global_cmvn is not None:
+            xs = self.global_cmvn(xs)
+        xs, pos_emb, _ = self.embed(xs, tmp_masks, offset)
+        elayers, cache_t1 = att_cache.size(0), att_cache.size(2)
+        chunk_size = xs.size(1)
+        attention_key_size = cache_t1 + chunk_size
+        if att_mask.size(-1) == 0 and attention_key_size > 0:
+            att_mask = torch.zeros(
+                (1, chunk_size, attention_key_size),
+                dtype=xs.dtype,
+                device=xs.device,
+            )
+        elif att_mask.dtype == torch.bool:
+            att_mask = mask_to_bias(att_mask, xs.dtype)
+        pos_emb = self.embed.pos_enc.position_encoding(offset=offset - cache_t1,
+                                                       size=attention_key_size)
+        if required_cache_size < 0:
+            next_cache_start = 0
+        elif required_cache_size == 0:
+            next_cache_start = attention_key_size
+        else:
+            next_cache_start = max(attention_key_size - required_cache_size, 0)
+        r_att_cache = []
+        r_cnn_cache = []
+        for i, layer in enumerate(self.encoders):
+            if elayers == 0:
+                kv_cache = (att_cache, att_cache)
+            else:
+                i_kv_cache = att_cache[i:i + 1]
+                size = att_cache.size(-1) // 2
+                kv_cache = (i_kv_cache[:, :, :, :size], i_kv_cache[:, :, :,
+                                                                   size:])
+            xs, new_kv_cache, new_cnn_cache = layer(
+                xs,
+                att_mask,
+                pos_emb,
+                att_cache=kv_cache,
+                cnn_cache=cnn_cache[i] if cnn_cache.size(0) > 0 else cnn_cache)
+            new_att_cache = torch.cat(new_kv_cache, dim=-1)
+            r_att_cache.append(new_att_cache[:, :, next_cache_start:, :])
+            r_cnn_cache.append(new_cnn_cache.unsqueeze(0))
+        if self.normalize_before and self.final_norm:
+            xs = self.after_norm(xs)
+
+        r_att_cache = torch.cat(r_att_cache, dim=0)
+        r_cnn_cache = torch.cat(r_cnn_cache, dim=0)
+
+        return (xs, r_att_cache, r_cnn_cache)
+
+    def forward_chunk_by_chunk(
+        self,
+        xs: torch.Tensor,
+        decoding_chunk_size: int,
+        num_decoding_left_chunks: int = -1,
+    ) -> torch.Tensor:
+        """ Forward input chunk by chunk with chunk_size like a streaming
+            fashion
+
+        Here we should pay special attention to computation cache in the
+        streaming style forward chunk by chunk. Three things should be taken
+        into account for computation in the current network:
+            1. transformer/conformer encoder layers output cache
+            2. convolution in conformer
+            3. convolution in subsampling
+
+        However, we don't implement subsampling cache for:
+            1. We can control subsampling module to output the right result by
+               overlapping input instead of cache left context, even though it
+               wastes some computation, but subsampling only takes a very
+               small fraction of computation in the whole model.
+            2. Typically, there are several covolution layers with subsampling
+               in subsampling module, it is tricky and complicated to do cache
+               with different convolution layers with different subsampling
+               rate.
+            3. Currently, nn.Sequential is used to stack all the convolution
+               layers in subsampling, we need to rewrite it to make it work
+               with cache, which is not prefered.
+        Args:
+            xs (torch.Tensor): (1, max_len, dim)
+            chunk_size (int): decoding chunk size
+        """
+        assert decoding_chunk_size > 0
+        subsampling = self.embed.subsampling_rate
+        context = self.embed.right_context + 1  # Add current frame
+        stride = subsampling * decoding_chunk_size
+        decoding_window = (decoding_chunk_size - 1) * subsampling + context
+        num_frames = xs.size(1)
+        att_cache: torch.Tensor = torch.zeros((0, 0, 0, 0), device=xs.device)
+        cnn_cache: torch.Tensor = torch.zeros((0, 0, 0, 0), device=xs.device)
+        outputs = []
+        offset = 0
+        required_cache_size = decoding_chunk_size * num_decoding_left_chunks
+
+        # Feed forward overlap input step by step
+        for cur in range(0, num_frames - context + 1, stride):
+            end = min(cur + decoding_window, num_frames)
+            chunk_xs = xs[:, cur:end, :]
+            (logits, att_cache, cnn_cache) = self.forward_chunk(chunk_xs, offset,
+                                                                required_cache_size, att_cache,
+                                                                cnn_cache)
+            outputs.append(logits)
+            offset += logits.size(1)
+        outputs = torch.cat(outputs, 1)
+        return outputs
 
 
 class ConformerModel(nn.Module):
+    """Conformer model: encoder + CTC."""
 
     def __init__(
         self,
@@ -533,7 +680,33 @@ class ConformerModel(nn.Module):
         self,
         input_features: torch.Tensor,
         lengths: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        hidden_states, masks = self.encoder(input_features, lengths)
-        logits = self.ctc(hidden_states)
-        return logits
+    ) -> torch.Tensor:
+        hidden_states, _ = self.encoder(input_features, lengths)
+        probs = self.ctc(hidden_states)
+        return probs
+
+    def forward_chunk(
+        self,
+        input_features: torch.Tensor,
+        offset: int,
+        required_cache_size: int,
+        att_cache: torch.Tensor = torch.zeros(0, 0, 0, 0),
+        cnn_cache: torch.Tensor = torch.zeros(0, 0, 0, 0),
+        att_mask: torch.Tensor = torch.zeros((0, 0, 0)),
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        hidden_states, att_cache, cnn_cache = self.encoder.forward_chunk(
+            input_features, offset, required_cache_size, att_cache, cnn_cache, att_mask)
+
+        probs = self.ctc(hidden_states)
+        return probs, att_cache, cnn_cache
+
+    def forward_chunk_by_chunk(
+        self,
+        input_features: torch.Tensor,
+        decoding_chunk_size: int,
+        num_decoding_left_chunks: int = -1,
+    ) -> torch.Tensor:
+        outputs = self.encoder.forward_chunk_by_chunk(
+            input_features, decoding_chunk_size, num_decoding_left_chunks)
+        probs = self.ctc(outputs)
+        return probs

--- a/tests/python/unit/test_conformer.py
+++ b/tests/python/unit/test_conformer.py
@@ -142,6 +142,94 @@ def test_conformer_encoder_matches_wenet(
     torch.testing.assert_close(impl_out, ref_out, rtol=5e-2, atol=5e-2)
 
 
+@pytest.mark.parametrize("chunk_size", [2, 4])
+@pytest.mark.parametrize("num_blocks", [1, 2])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_forward_chunk_encoder_matches_wenet(
+    chunk_size: int,
+    num_blocks: int,
+    dtype: torch.dtype,
+):
+    """Encoder forward_chunk output matches the WeNet ConformerEncoder.forward_chunk."""
+    if dtype == torch.bfloat16 and not torch.cuda.is_available():
+        pytest.skip("bfloat16 requires CUDA")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(7)
+
+    wenet_encoder_config = make_encoder_config(
+        output_size=64,
+        num_blocks=num_blocks,
+        attention_heads=2,
+        linear_units=128,
+        use_cnn_module=True,
+        cnn_module_kernel=15,
+        use_sdpa=True,
+    )
+
+    ref_encoder = wenet_encoder.ConformerEncoder(**wenet_encoder_config)
+    impl_encoder = ConformerEncoder(ConformerEncoderConfig(
+        input_size=wenet_encoder_config["input_size"],
+        output_size=wenet_encoder_config["output_size"],
+        num_blocks=wenet_encoder_config["num_blocks"],
+        attention_heads=wenet_encoder_config["attention_heads"],
+        linear_units=wenet_encoder_config["linear_units"],
+        use_cnn_module=wenet_encoder_config["use_cnn_module"],
+        cnn_module_kernel=wenet_encoder_config["cnn_module_kernel"],
+        embed_layer_norm=False,  # match WeNet default (no LayerNorm in embed)
+    ))
+
+    ref_sd = ref_encoder.state_dict()
+    load_sd = {k: ref_sd[k] for k in impl_encoder.state_dict() if k in ref_sd}
+    impl_encoder.load_state_dict(load_sd, strict=False)
+
+    ref_encoder = ref_encoder.eval().to(dtype=dtype, device=device)
+    impl_encoder = impl_encoder.eval().to(dtype=dtype, device=device)
+
+    time_in = chunk_input_time(chunk_size)
+    xs = torch.randn(1, time_in, 80, dtype=dtype, device=device)
+    offset = 0
+    required_cache_size = -1
+    att_cache = torch.zeros(0, 0, 0, 0, dtype=dtype, device=device)
+    cnn_cache = torch.zeros(0, 0, 0, 0, dtype=dtype, device=device)
+    # Both WeNet and OASR attention expect additive bias (float), not bool. First chunk: key_size = chunk_size.
+    att_mask_bias = torch.zeros(
+        1, chunk_size, chunk_size, dtype=dtype, device=device)
+
+    with torch.no_grad():
+        ref_out, ref_att_cache, ref_cnn_cache = ref_encoder.forward_chunk(
+            xs,
+            offset,
+            required_cache_size,
+            att_cache=att_cache,
+            cnn_cache=cnn_cache,
+            att_mask=att_mask_bias,
+        )
+        impl_out, impl_att_cache, impl_cnn_cache = impl_encoder.forward_chunk(
+            xs,
+            offset,
+            required_cache_size,
+            att_cache=att_cache,
+            cnn_cache=cnn_cache,
+            att_mask=att_mask_bias,
+        )
+
+    assert ref_out.shape == impl_out.shape, (
+        f"output shape: WeNet {ref_out.shape} vs OASR {impl_out.shape}"
+    )
+    torch.testing.assert_close(impl_out, ref_out, rtol=5e-2, atol=5e-2)
+    assert ref_att_cache.shape == impl_att_cache.shape, (
+        f"att_cache shape: WeNet {ref_att_cache.shape} vs OASR {impl_att_cache.shape}"
+    )
+    torch.testing.assert_close(
+        impl_att_cache, ref_att_cache, rtol=5e-2, atol=5e-2)
+    assert ref_cnn_cache.shape == impl_cnn_cache.shape, (
+        f"cnn_cache shape: WeNet {ref_cnn_cache.shape} vs OASR {impl_cnn_cache.shape}"
+    )
+    if ref_cnn_cache.numel() > 0:
+        torch.testing.assert_close(
+            impl_cnn_cache, ref_cnn_cache, rtol=5e-2, atol=5e-2)
+
+
 def load_wenet_model_from_ckpt_dir(ckpt_dir: Path, device: str):
     """Load full WeNet ASR model from checkpoint dir (train.yaml + final.pt)."""
     yaml_path = ckpt_dir / "train.yaml"
@@ -159,6 +247,195 @@ def load_wenet_model_from_ckpt_dir(ckpt_dir: Path, device: str):
     model, _ = init_model(args, configs)
     model = model.to(device).eval()
     return model
+
+
+def chunk_input_time(chunk_size: int, subsample_rate: int = 4, right_context: int = 6) -> int:
+    """Input time length for one chunk so that after subsampling we get chunk_size frames."""
+    return (chunk_size - 1) * subsample_rate + right_context + 1
+
+
+@pytest.mark.parametrize("chunk_size", [2, 4, 8])
+@pytest.mark.parametrize("num_blocks", [1, 2])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_forward_chunk_encoder_shapes(
+    chunk_size: int,
+    num_blocks: int,
+    dtype: torch.dtype,
+):
+    """Encoder forward_chunk returns correct output and cache shapes (b=1, empty caches)."""
+    if dtype == torch.bfloat16 and not torch.cuda.is_available():
+        pytest.skip("bfloat16 requires CUDA")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(3)
+
+    config = ConformerEncoderConfig(
+        input_size=80,
+        output_size=64,
+        num_blocks=num_blocks,
+        attention_heads=2,
+        linear_units=128,
+        use_cnn_module=True,
+        cnn_module_kernel=15,
+        causal=False,
+    )
+    encoder = ConformerEncoder(config).eval().to(device=device, dtype=dtype)
+
+    time_in = chunk_input_time(chunk_size)
+    xs = torch.randn(1, time_in, 80, dtype=dtype, device=device)
+    offset = 0
+    required_cache_size = -1  # keep full history
+    att_cache = torch.zeros(0, 0, 0, 0, dtype=dtype, device=device)
+    cnn_cache = torch.zeros(0, 0, 0, 0, dtype=dtype, device=device)
+
+    with torch.no_grad():
+        out, r_att_cache, r_cnn_cache = encoder.forward_chunk(
+            xs, offset, required_cache_size, att_cache, cnn_cache
+        )
+
+    assert out.shape == (1, chunk_size, 64), f"out shape {out.shape}"
+    assert r_att_cache.dim() == 4
+    assert r_att_cache.size(0) == num_blocks
+    assert r_att_cache.size(1) == 2  # attention_heads
+    # required_cache_size < 0 -> keep all
+    assert r_att_cache.size(2) == chunk_size
+    assert r_att_cache.size(3) == 64  # d_k * 2 for key+value
+    assert r_cnn_cache.dim() == 4
+    assert r_cnn_cache.size(0) == num_blocks
+    # causal=False -> lorder=0; cnn_cache can be (elayers, 0, 0, 0) when no conv cache
+    assert r_cnn_cache.size(2) == 0
+    assert r_cnn_cache.size(3) == 0 or r_cnn_cache.size(3) == 64
+
+
+@pytest.mark.parametrize("chunk_size", [4])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_forward_chunk_encoder_first_chunk_matches_full(chunk_size: int, dtype: torch.dtype):
+    """First chunk with empty cache should match full encoder on the same input (single chunk)."""
+    if dtype == torch.bfloat16 and not torch.cuda.is_available():
+        pytest.skip("bfloat16 requires CUDA")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(4)
+
+    config = ConformerModelConfig(
+        encoder=ConformerEncoderConfig(
+            input_size=80,
+            output_size=64,
+            num_blocks=1,
+            attention_heads=2,
+            linear_units=128,
+            use_cnn_module=True,
+            cnn_module_kernel=15,
+            causal=False,
+        ),
+        vocab_size=128,
+    )
+    model = ConformerModel(config).eval().to(device=device, dtype=dtype)
+
+    time_in = chunk_input_time(chunk_size)
+    xs = torch.randn(1, time_in, 80, dtype=dtype, device=device)
+    xs_lens = torch.full((1,), time_in, dtype=torch.long, device=device)
+
+    with torch.no_grad():
+        full_out = model(xs, xs_lens)
+        chunk_out, _, _ = model.forward_chunk(
+            xs,
+            offset=0,
+            required_cache_size=-1,
+            att_cache=torch.zeros(0, 0, 0, 0, dtype=dtype, device=device),
+            cnn_cache=torch.zeros(0, 0, 0, 0, dtype=dtype, device=device),
+        )
+
+    assert full_out.shape == chunk_out.shape
+    torch.testing.assert_close(chunk_out, full_out, rtol=5e-2, atol=5e-2)
+
+
+@pytest.mark.parametrize("chunk_size", [64])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_forward_chunk_encoder_two_chunks(chunk_size: int, dtype: torch.dtype):
+    """Two consecutive chunks with cache: shapes and no crash."""
+    if dtype == torch.bfloat16 and not torch.cuda.is_available():
+        pytest.skip("bfloat16 requires CUDA")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(5)
+
+    config = ConformerEncoderConfig(
+        input_size=80,
+        output_size=64,
+        num_blocks=1,
+        attention_heads=2,
+        linear_units=128,
+        use_cnn_module=True,
+        cnn_module_kernel=15,
+        causal=False,
+    )
+    encoder = ConformerEncoder(config).eval().to(device=device, dtype=dtype)
+
+    time_in = chunk_input_time(chunk_size)
+    xs1 = torch.randn(1, time_in, 80, dtype=dtype, device=device)
+    xs2 = torch.randn(1, time_in, 80, dtype=dtype, device=device)
+
+    with torch.no_grad():
+        out1, att_cache, cnn_cache = encoder.forward_chunk(
+            xs1, offset=0, required_cache_size=chunk_size,
+            att_cache=torch.zeros(0, 0, 0, 0, dtype=dtype, device=device),
+            cnn_cache=torch.zeros(0, 0, 0, 0, dtype=dtype, device=device),
+        )
+    assert out1.shape == (1, chunk_size, 64)
+    assert att_cache.shape[0] == 1 and att_cache.shape[1] == 2
+    assert cnn_cache.dim() == 4 and cnn_cache.size(0) == 1
+
+    with torch.no_grad():
+        out2, att_cache2, cnn_cache2 = encoder.forward_chunk(
+            xs2, offset=chunk_size, required_cache_size=chunk_size,
+            att_cache=att_cache, cnn_cache=cnn_cache,
+        )
+    assert out2.shape == (1, chunk_size, 64)
+    assert att_cache2.shape[0] == 1
+    assert cnn_cache2.shape[0] == 1
+
+
+@pytest.mark.parametrize("chunk_size", [4])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_forward_chunk_model_shapes(chunk_size: int, dtype: torch.dtype):
+    """Conformer encoder forward_chunk + CTC produce expected shapes (logits, att_cache, cnn_cache).
+    Logits are computed via F.linear to avoid custom GEMM NOT_SUPPORTED for small chunk sizes.
+    """
+    if dtype == torch.bfloat16 and not torch.cuda.is_available():
+        pytest.skip("bfloat16 requires CUDA")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(6)
+
+    config = ConformerModelConfig(
+        encoder=ConformerEncoderConfig(
+            input_size=80,
+            output_size=64,
+            num_blocks=1,
+            attention_heads=2,
+            linear_units=128,
+            use_cnn_module=True,
+            cnn_module_kernel=15,
+            causal=False,
+        ),
+        vocab_size=128,
+    )
+    model = ConformerModel(config).eval().to(device=device, dtype=dtype)
+
+    time_in = chunk_input_time(chunk_size)
+    xs = torch.randn(1, time_in, 80, dtype=dtype, device=device)
+    att_cache = torch.zeros(0, 0, 0, 0, dtype=dtype, device=device)
+    cnn_cache = torch.zeros(0, 0, 0, 0, dtype=dtype, device=device)
+
+    with torch.no_grad():
+        probs, att_cache, cnn_cache = model.forward_chunk(
+            xs,
+            offset=0,
+            required_cache_size=-1,
+            att_cache=att_cache,
+            cnn_cache=cnn_cache,
+        )
+
+    assert probs.shape == (1, chunk_size, 128)
+    assert att_cache.dim() == 4 and att_cache.size(0) == 1
+    assert cnn_cache.dim() == 4 and cnn_cache.size(0) == 1
 
 
 @pytest.mark.parametrize("batch,time_in,feat_dim", [(2, 80, 80), (1, 60, 80)])

--- a/tests/python/unit/test_decoder.py
+++ b/tests/python/unit/test_decoder.py
@@ -47,6 +47,33 @@ class TestCtcPrefixBeamSearch:
             )
             return feats
 
+        def build_dictionary(ckpt_dir: str):
+            """Build dictionary from words.txt."""
+            id2word = {}
+            with open(Path(ckpt_dir) / "words.txt", "r") as f:
+                for line in f.readlines():
+                    word, idx = line.strip().split()
+                    id2word[int(idx)] = word
+            return id2word
+
+        def decode(probs: torch.Tensor, id2word: dict[int, str]):
+            """Detokenize outputs."""
+            decoder = CtcPrefixBeamSearch(
+                blank=0, first_beam_size=10, second_beam_size=10)
+
+            probs = probs.squeeze(0).to(device="cpu", dtype=torch.float32)
+
+            decoder.reset()
+            decoder.search(probs)
+            decoder.finalize_search()
+
+            outputs = decoder.outputs
+            likelihood = decoder.likelihood
+
+            text = "".join([id2word[idx]
+                           for idx in outputs[0]]).replace("▁", " ").strip()
+            return text, likelihood
+
         # Run the encoder on CUDA using the requested half/bfloat16 dtype.
         device = "cuda"
         oasr_model, _ = load_wenet_checkpoint(
@@ -68,32 +95,24 @@ class TestCtcPrefixBeamSearch:
 
         with torch.no_grad():
             probs = oasr_model(feats, lengths)
+            chunk_by_chunk_probs = oasr_model.forward_chunk_by_chunk(
+                feats, decoding_chunk_size=4, num_decoding_left_chunks=2)
 
         # CtcPrefixBeamSearch expects log-probs of shape [T, V] on CPU in
         # float32; collapse the batch dimension and move to CPU.
         probs = probs.squeeze(0).to(device="cpu", dtype=dtype)
+        chunk_by_chunk_probs = chunk_by_chunk_probs.squeeze(
+            0).to(device="cpu", dtype=dtype)
 
-        decoder.reset()
-        decoder.search(probs)
-        decoder.finalize_search()
+        id2word = build_dictionary(ckpt_dir)
 
-        outputs = decoder.outputs
-        likelihood = decoder.likelihood
+        text, _ = decode(probs, id2word)
+        chunk_by_chunk_text, _ = decode(chunk_by_chunk_probs, id2word)
+        print(f"text: {text}")
+        print(f"chunk_by_chunk_text: {chunk_by_chunk_text}")
 
-        id2word = {}
-        with open(Path(ckpt_dir) / "words.txt", "r") as f:
-            for line in f.readlines():
-                word, idx = line.strip().split()
-                id2word[int(idx)] = word
-
-        text = "".join([id2word[idx]
-                       for idx in outputs[0]]).replace("▁", " ").strip()
-        print(f"text: {text}, likelihood: {likelihood[0]}")
-
-        assert len(outputs) >= 1
-        assert isinstance(outputs[0], list)
-        assert isinstance(likelihood[0], float)
         assert len(text.split()) > 0
+        assert len(chunk_by_chunk_text.split()) > 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…ests

- Implemented forward_chunk method in ConformerEncoder for processing input in chunks.
- Added unit tests to validate forward_chunk output against WeNet's implementation.
- Enhanced existing tests to ensure correct output shapes and cache handling for chunked inputs.
- Updated test utilities for better compatibility with varying chunk sizes and data types.