### PR TITLE
fix: Correct handling of empty-row clamp in softmax to maintain accur…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,12 @@ JIT compilation and a Rust HTTP/gRPC serving front-end.
    that changes *what is decoded* or that a caller will look for in the response
    must be declared (`selective_options` / `word_timing_modes`) so a family
    without it rejects rather than ignores.
-10. **Never pass `-inf` as `attn_bias`.** Use a large finite mask floor —
-    mathematically identical, and the fused kernel is inaccurate above a
-    moderate finite bias magnitude.
+10. **Never let a fully masked K-tile become the carried `row_max`.** The online
+    softmax's empty-row clamp (`row_max == -inf` → 0) must stay *local to the
+    tile*: stored, the running max becomes `max(0, m)`, `P` loses `max(P) == 1`,
+    and the fp16 cast before `P @ V` flushes the row to zero. That is what made
+    `-inf` in `attn_bias` wrong beside a large finite bias; fixed and pinned by
+    `tests/test_fmha.py::TestInfiniteMaskFloorWithALargeBias`.
 11. **Never branch kernel dispatch on CUDA-graph capture state.** A
     capture-dependent branch makes the graph pick a different kernel than eager,
     and the resulting one-ulp difference has changed decoded tokens.

--- a/oasr/kernels/cute/attention/fmha_sm80.py
+++ b/oasr/kernels/cute/attention/fmha_sm80.py
@@ -32,8 +32,10 @@ Key features (Tier 2 cp.async ring matching FA's flash_fwd SM80 path):
 * :class:`AttentionMask` carries the per-stream length, causal, and
   sliding-window mask in one constexpr-flagged loop. Causal / window-size
   knobs are wired through ``FmhaBase`` and default off.
-* Online softmax lives in :class:`Softmax`. Empty-row clamp
-  (``row_max == -inf`` => 0) carries over.
+* Online softmax lives in :class:`Softmax`. The empty-row clamp
+  (``row_max == -inf`` => 0) is local to the tile; the carried
+  ``row_max`` keeps ``-inf`` so a fully masked tile does not become the
+  running max.
 * Paged KV uses ``_paged_load_kv_tile`` on this class. Same
   block-aligned-``n_block`` constraint as before
   (``N_BLOCK % block_size == 0``).

--- a/oasr/kernels/cute/softmax.py
+++ b/oasr/kernels/cute/softmax.py
@@ -32,6 +32,19 @@ Both ``exp2`` arguments are formed as ``(a - b) * scale_log2`` and **never**
 as ``a * scale_log2 - b * scale_log2``. The two are algebraically equal but
 not numerically equal under ``fastmath``, and the difference is the
 correctness of the whole block -- see :meth:`Softmax.online_softmax`.
+
+The carried ``row_max`` is the *true* max, ``-inf`` included. A K-tile in
+which every column is masked leaves it at ``-inf``, and the ``exp2``
+reference for that tile alone is clamped to 0 (``exp2((-inf) - (-inf))``
+is NaN). Storing the clamp instead -- which is what this block used to do
+-- turns the running max into ``max(0, m)``, so every later tile whose own
+max ``m`` is negative gets exponentiated about 0 rather than about ``m``.
+Step 2 then no longer has ``max(P) == 1``, which is exactly the invariant
+that makes the caller's cast of ``P`` down to fp16/bf16 lossless: at
+``m = -11`` the whole row lands in fp16's subnormals, and below ``m = -20``
+it flushes to zero while ``row_sum`` (fp32) does not, so the row comes back
+scaled wrong or empty. ``m`` is a *logit*, so plain attention never reaches
+those magnitudes -- an additive ``attn_bias`` does.
 """
 
 # PEP 563 (deferred annotations) breaks CuteDSL Constexpr detection;
@@ -115,9 +128,15 @@ class Softmax:
         JIT drop a register-rich branch.
 
         Caller must have already masked invalid columns/rows in ``acc_S``
-        to ``-inf`` via :class:`AttentionMask`. The empty-row clamp
-        (``row_max == -inf`` => set to 0 to avoid NaN from exp(-inf -
-        -inf)) is applied here.
+        to ``-inf`` via :class:`AttentionMask`.
+
+        A row every one of whose columns is masked has ``row_max == -inf``,
+        and ``exp2((-inf) - (-inf))`` is NaN, so the ``exp2`` *reference*
+        is clamped to 0 for that row -- but the clamp stays local to the
+        tile. The **carried** ``row_max`` keeps the true ``-inf``: storing
+        the clamped 0 would make the running max ``max(0, m) == 0`` for
+        every later tile whose real max ``m`` is negative, and the softmax
+        would then be taken about the wrong point -- see the class notes.
         """
         acc_S_mn = make_acc_mn_view(acc_S)
         acc_O_mn = make_acc_mn_view(acc_O)
@@ -139,32 +158,49 @@ class Softmax:
             if cutlass.const_expr(not is_first):
                 row_max_cur = cute.arch.fmax(row_max_prev[r], row_max_cur)
 
-            # Empty-row clamp: if every column was masked to -inf, the
-            # subsequent ``exp(-inf - -inf)`` is NaN. Replace by 0 so
-            # ``exp(-inf - 0) = 0`` and row_sum stays 0; downstream
-            # arithmetic stays finite.
-            row_max_cur = 0.0 if row_max_cur == -cutlass.Float32.inf else row_max_cur
+            # Carry the *true* running max, ``-inf`` included: an all-masked
+            # tile must leave it at -inf so the next tile's real max wins
+            # outright. Clamping the carried value to 0 (which this used to do)
+            # keeps ``max(0, m) == 0`` for every negative ``m``, and the tile
+            # is then exponentiated about 0 instead of about its own max.
+            self.row_max[r] = row_max_cur
+
+            # Empty-row reference: ``exp2((-inf) - (-inf))`` is NaN, so a row
+            # with no unmasked column so far exponentiates about 0 instead --
+            # every one of its entries is -inf, so every ``row_p`` is 0 and
+            # row_sum stays 0 whatever finite reference is used.
+            row_max_ref = 0.0 if row_max_cur == -cutlass.Float32.inf else row_max_cur
 
             # Subtract before scaling. Under fastmath, the two-multiply form can
             # round the maximum's exponent positive, violating ``exp2(arg) <= 1``.
             # Finite mask floors make this overflow observable on masked blocks;
             # subtract-first preserves the sign and matches the rescale below.
             row_p = cute.math.exp2(
-                (acc_S_row - row_max_cur) * scale_log2,
+                (acc_S_row - row_max_ref) * scale_log2,
                 fastmath=True,
             )
             row_sum_cur = row_p.reduce(cute.ReductionOp.ADD, cutlass.Float32.zero, 0)
 
             if cutlass.const_expr(not is_first):
+                # Rebase the accumulators from the reference they were built
+                # against onto this tile's. A -inf previous max means nothing
+                # has been accumulated yet (row_sum and this acc_O row are both
+                # exactly 0), which is ``exp2(-inf) == 0``; spelling that out
+                # keeps -inf out of the arithmetic, where a
+                # ``0.0 * inf == NaN`` is one overflowing exponent away.
                 # Subtract-first keeps the non-positive rescale exponent exact.
-                delta_exp = cute.math.exp2(
-                    (row_max_prev[r] - row_max_cur) * scale_log2,
-                    fastmath=True,
+                prev_empty = row_max_prev[r] == -cutlass.Float32.inf
+                delta_exp = (
+                    cutlass.Float32(0.0)
+                    if prev_empty
+                    else cute.math.exp2(
+                        (row_max_prev[r] - row_max_ref) * scale_log2,
+                        fastmath=True,
+                    )
                 )
                 row_sum_cur = row_sum_cur + self.row_sum[r] * delta_exp
                 acc_O_mn[r, None] = acc_O_mn[r, None].load() * delta_exp
 
-            self.row_max[r] = row_max_cur
             self.row_sum[r] = row_sum_cur
             acc_S_mn[r, None] = row_p
 

--- a/oasr/models/conformer/model.py
+++ b/oasr/models/conformer/model.py
@@ -47,7 +47,9 @@ def mask_to_bias(mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
     assert mask.dtype == torch.bool
     assert dtype in [torch.float32, torch.bfloat16, torch.float16]
     mask = mask.to(dtype)
-    # Keep the mask finite; fused attention is inaccurate with an infinite bias.
+    # A finite floor, which fp16 promptly overflows back to -inf -- harmless
+    # either way: the mask is exact for both, and the fused kernel's inaccuracy
+    # with an infinite bias is fixed (see oasr/kernels/cute/softmax.py).
     mask = (1.0 - mask) * -1.0e10
     return mask
 

--- a/oasr/models/nemotron/encoder.py
+++ b/oasr/models/nemotron/encoder.py
@@ -67,15 +67,19 @@ __all__ = [
 ]
 
 #: Additive bias given to a masked attention key.  A **finite** floor, where
-#: upstream writes ``float("-inf")``, and the difference is not cosmetic.
+#: upstream writes ``float("-inf")``.
 #:
 #: Masking is exact either way: this bias is added after the softmax scale, the
 #: real logits stay far above this floor, and the masked exponent underflows to
-#: zero.  The finite form avoids a fused-attention accuracy defect when an
-#: infinite mask is combined with a large finite relative-position bias.
-#:
-#: A fully masked query row also stays finite; an infinite mask can produce a NaN
-#: row that later arithmetic spreads into valid rows.
+#: zero -- so for any row with at least one unmasked key the two forms are
+#: bit-identical.  The floor was introduced to dodge a fused-attention accuracy
+#: defect that ``-inf`` triggered next to this architecture's large
+#: Transformer-XL bias; that defect is fixed (``oasr/kernels/cute/softmax.py``,
+#: pinned by ``tests/test_fmha.py::TestInfiniteMaskFloorWithALargeBias``), so the
+#: floor is now a choice rather than a workaround.  It stays because the WER this
+#: architecture is gated on was measured with it, and because it keeps a fully
+#: masked query row a finite average instead of leaving the row's value to the
+#: backend.
 MASK_FLOOR = -1.0e4
 
 
@@ -343,9 +347,8 @@ class NemotronRelPositionAttention(nn.Module):
         matrix_bd = (q + self.bias_v.unsqueeze(1)) @ rel_k.permute(0, 2, 3, 1)
         matrix_bd = rel_shift(matrix_bd)[..., :key_len] * self.scaling
 
-        # A large *finite* floor rather than upstream's ``-inf``: mathematically
-        # the same mask, and the one the fused kernel computes correctly at this
-        # bias magnitude.  See :data:`MASK_FLOOR` for the measurement.
+        # A large *finite* floor rather than upstream's ``-inf``: the same mask
+        # for every row with a live key.  See :data:`MASK_FLOOR`.
         bias = matrix_bd.masked_fill(attn_mask.logical_not(), MASK_FLOOR)
         out = self.attn(q + self.bias_u.unsqueeze(1), k, v, attn_bias=bias)
         if silent is not None:

--- a/tests/test_fmha.py
+++ b/tests/test_fmha.py
@@ -356,32 +356,54 @@ def test_fmha_finite_mask_floor_stays_finite(fmha, cuda, dtype, mask_floor):
 
 
 class TestInfiniteMaskFloorWithALargeBias:
-    """Large finite biases require the finite mask floor.
+    """``-inf`` in ``attn_bias`` has to mean what SDPA means by it.
 
-    Sparse rows can make fused softmax inaccurate when ``-inf`` is combined with
-    a large finite bias. The finite-floor arm is required behavior; the strict
-    xfail makes removal of the workaround explicit when the kernel is fixed.
+    The kernel used to write the *empty-row clamp* into the carried
+    ``row_max``: a K-tile with no unmasked column at all left the running max
+    at ``0`` instead of ``-inf``, so every later tile whose own max ``m`` was
+    negative got exponentiated about 0 rather than about ``m``.  ``P`` then
+    lost the ``max(P) == 1`` invariant that makes the cast down to fp16/bf16
+    before ``P @ V`` lossless -- subnormal by ``m ~ -11``, flushed to zero by
+    ``m ~ -20`` -- while ``row_sum`` stayed fp32-exact, so the row came back
+    mis-scaled or empty.  ``m`` is a logit: nothing but an additive bias gets
+    it that far from 0, which is why plain attention -- and FlashAttention,
+    whose softmax block this one mirrors -- never sees it.
+
+    Two things therefore decide a case, and both are in the geometries below:
+    a **fully masked first-visited K-tile** (the n-block loop runs descending,
+    so that is the *last* tile of the row) and a **negative row max**.  A
+    large finite floor (``-1e4``) never triggered it, because a finite floor
+    is itself a finite row max.
     """
 
+    # (B, H, T, D) shared by every case here so each dtype compiles once.
+    SHAPE = (3, 8, 122, 128)
+
     @staticmethod
-    def _case(cuda, dtype, floor):
-        B, H, T, D, magnitude = 3, 8, 122, 128, 80.0
+    def _chunked_window(T, device, chunk_size=4, history=14):
+        """NeMo's ``chunked_limited`` window, inline so this file stays
+        independent of the model package: frames are grouped into chunks of
+        ``right + 1 = 4`` and a query sees its own chunk plus the previous
+        ``56 // 4 = 14``.  The first chunk therefore leaves only 4 unmasked
+        keys, and its rows are the ones that failed.  Every row keeps its own
+        diagonal, so none is empty and the comparison is about accuracy, not
+        empty-row handling.
+        """
+        chunk = torch.arange(T, device=device).div(chunk_size, rounding_mode="trunc")
+        diff = chunk.unsqueeze(1) - chunk.unsqueeze(0)
+        return (diff >= 0) & (diff <= history)
+
+    @classmethod
+    def _case(cls, cuda, dtype, floor, magnitude=80.0, offset=0.0, keep=None):
+        B, H, T, D = cls.SHAPE
         torch.manual_seed(0)
         q = torch.randn(B, H, T, D, device=cuda, dtype=dtype) * 0.5
         k = torch.randn(B, H, T, D, device=cuda, dtype=dtype) * 0.5
         v = torch.randn(B, H, T, D, device=cuda, dtype=dtype) * 0.5
-        # NeMo's ``chunked_limited`` window, inline so this file stays independent
-        # of the model package: frames are grouped into chunks of ``right + 1 = 4``
-        # and a query sees its own chunk plus the previous ``56 // 4 = 14``.  The
-        # first chunk therefore leaves only 4 unmasked keys, which is the row that
-        # fails.  Every row keeps its own diagonal, so none is empty and the
-        # comparison is about accuracy, not empty-row handling.
-        chunk = torch.arange(T, device=cuda).div(4, rounding_mode="trunc")
-        diff = chunk.unsqueeze(1) - chunk.unsqueeze(0)
-        keep = (diff >= 0) & (diff <= 14)
-        bias = (torch.randn(B, H, T, T, device=cuda, dtype=dtype) * magnitude).masked_fill(
-            ~keep.view(1, 1, T, T), floor
-        )
+        if keep is None:
+            keep = cls._chunked_window(T, cuda)
+        bias = torch.randn(B, H, T, T, device=cuda, dtype=dtype) * magnitude + offset
+        bias = bias.masked_fill(~keep.view(1, 1, T, T), floor)
         scale = 1.0 / math.sqrt(D)
         return q, k, v, bias, scale
 
@@ -392,22 +414,117 @@ class TestInfiniteMaskFloorWithALargeBias:
         ref = _ref_fmha(q, k, v, scale, attn_bias=bias)
         torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "known kernel defect: -inf in attn_bias is inaccurate once the finite "
-            "part of the bias exceeds ~±32 (see .artifacts/known_issues.md). Pass a "
-            "large finite floor instead; remove this xfail when the kernel is fixed"
-        ),
-    )
-    def test_large_bias_with_an_infinite_floor_matches_sdpa(self, fmha, cuda):
-        from oasr.jit.attention import select_backend
-
-        if select_backend() != "cute":
-            pytest.skip("defect is in the CuteDSL kernel; SDPA fallback is accurate")
-        q, k, v, bias, scale = self._case(cuda, torch.float16, float("-inf"))
+    @pytest.mark.parametrize("dtype", _DTYPES)
+    def test_large_bias_with_an_infinite_floor_matches_sdpa(self, fmha, cuda, dtype):
+        """The case the strict xfail used to pin.  Off by 1.49 on the pre-fix
+        kernel, on the 4-unmasked-key rows of the first chunk."""
+        q, k, v, bias, scale = self._case(cuda, dtype, float("-inf"))
         out = fmha(q, k, v, softmax_scale=scale, attn_bias=bias)
         ref = _ref_fmha(q, k, v, scale, attn_bias=bias)
+        torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+    @pytest.mark.parametrize("dtype", _DTYPES)
+    def test_the_two_floors_agree(self, fmha, cuda, dtype):
+        """``-inf`` and a large finite floor are the same mask, so they must
+        give the same answer -- the claim that retires the finite-floor
+        workaround, rather than each arm merely being within tolerance of
+        SDPA.  It is also the sharpest of these cases in bf16, where the wider
+        exponent kept the pre-fix error (0.0039) inside the SDPA tolerance
+        while the two floors still disagreed."""
+        args_inf = self._case(cuda, dtype, float("-inf"))
+        args_fin = self._case(cuda, dtype, -1.0e4)
+        q, k, v, bias_inf, scale = args_inf
+        bias_fin = args_fin[3]
+        out_inf = fmha(q, k, v, softmax_scale=scale, attn_bias=bias_inf)
+        out_fin = fmha(q, k, v, softmax_scale=scale, attn_bias=bias_fin)
+        torch.testing.assert_close(out_inf, out_fin, atol=0, rtol=0)
+
+    @pytest.mark.parametrize("offset", [-200.0, -90.0, -20.0, -11.0, 0.0, 90.0, 200.0])
+    def test_the_bias_offset_does_not_matter(self, fmha, cuda, offset):
+        """Shift the whole bias and watch the sign of the row max decide.
+
+        Softmax is shift-invariant, so adding a constant to every unmasked
+        logit must not move the output at all -- and on the pre-fix kernel it
+        did, at every offset here that left the sparse rows' max negative.  The
+        positive end passes on the broken kernel too, because the poisoned
+        running max is ``max(0, m)``, which is ``m`` exactly when ``m >= 0``:
+        that asymmetry is this defect's fingerprint, and it is why a symmetric
+        ``randn`` bias hides half of it.  With a *constant* bias in place of
+        this one's ``randn * 80``, the damage sets in at ``m ~ -11`` (fp16
+        subnormals) and is total by ``m ~ -20``.
+        """
+        q, k, v, bias, scale = self._case(cuda, torch.float16, float("-inf"), offset=offset)
+        out = fmha(q, k, v, softmax_scale=scale, attn_bias=bias)
+        ref = _ref_fmha(q, k, v, scale, attn_bias=bias)
+        torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+    @pytest.mark.parametrize("dtype", _DTYPES)
+    def test_several_fully_masked_leading_tiles(self, fmha, cuda, dtype):
+        """Only the first three keys survive, so the descending n-block loop
+        opens on two whole ``-inf`` tiles before it reaches a live column --
+        and with three keys per row the max is negative about half the time.
+        Off by 2.14 pre-fix, in both dtypes.
+        """
+        B, H, T, D = self.SHAPE
+        keep = torch.zeros(T, T, dtype=torch.bool, device=cuda)
+        keep[:, :3] = True
+        q, k, v, bias, scale = self._case(cuda, dtype, float("-inf"), keep=keep)
+        out = fmha(q, k, v, softmax_scale=scale, attn_bias=bias)
+        ref = _ref_fmha(q, k, v, scale, attn_bias=bias)
+        torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+    def test_empty_rows_stay_zero_next_to_a_large_bias(self, fmha, cuda):
+        """A row with no unmasked key at all still comes back zero, not NaN --
+        the kernel's documented empty-row behaviour, pinned on its own by
+        ``TestPerRowKeyStart.test_fully_masked_row_is_zero_not_nan`` -- and its
+        neighbours in the same tile are unaffected.  This is the case the
+        rescale has to survive: ``row_max_prev`` is ``-inf`` while
+        ``row_max_cur`` is finite, and forming that delta as
+        ``exp2((-inf) - m)`` rather than special-casing it would multiply an
+        all-zero accumulator by an exponent one overflow away from ``inf``.
+        """
+        B, H, T, D = self.SHAPE
+        keep = self._chunked_window(T, cuda).clone()
+        rows = torch.arange(T, device=cuda)
+        empty = (rows % 8) == 3
+        keep[empty] = False
+        q, k, v, bias, scale = self._case(cuda, torch.float16, float("-inf"), keep=keep)
+        out = fmha(q, k, v, softmax_scale=scale, attn_bias=bias)
+        ref = _ref_fmha(q, k, v, scale, attn_bias=bias)
+        assert torch.isfinite(out).all()
+        torch.testing.assert_close(out[:, :, empty], torch.zeros_like(out[:, :, empty]))
+        torch.testing.assert_close(out[:, :, ~empty], ref[:, :, ~empty], atol=2e-2, rtol=2e-2)
+
+    def test_paged_kv_with_an_infinite_floor(self, fmha, cuda):
+        """The paged path shares the softmax block, and shared is not the same
+        as covered: its tiles come from a block table, so it reaches
+        ``online_softmax`` through a different loader.  Off by 1.53 pre-fix."""
+        from oasr.functionals.attention import gather_paged_kv
+
+        B, H, D, block, nblk = 2, 4, 64, 16, 9
+        T_q, T_k = 128, block * nblk
+        torch.manual_seed(0)
+        k_pool = torch.randn(B * nblk, block, H, D, device=cuda, dtype=torch.float16) * 0.5
+        v_pool = torch.randn(B * nblk, block, H, D, device=cuda, dtype=torch.float16) * 0.5
+        bt = torch.arange(B * nblk, device=cuda, dtype=torch.int32).view(B, nblk)
+        q = torch.randn(B, H, T_q, D, device=cuda, dtype=torch.float16) * 0.5
+        keep = self._chunked_window(max(T_q, T_k), cuda)[:T_q, :T_k]
+        bias = torch.randn(B, H, T_q, T_k, device=cuda, dtype=torch.float16) * 80.0
+        bias = bias.masked_fill(~keep.view(1, 1, T_q, T_k), float("-inf"))
+        scale = 1.0 / math.sqrt(D)
+
+        lens = torch.tensor([T_k, T_k - 20], device=cuda, dtype=torch.int32)
+        out = fmha(
+            q,
+            k_pool,
+            v_pool,
+            softmax_scale=scale,
+            attn_bias=bias,
+            cache_seqlens=lens,
+            block_table=bt,
+        )
+        k_dense, v_dense = gather_paged_kv(k_pool, v_pool, bt)
+        ref = _ref_fmha(q, k_dense, v_dense, scale, attn_bias=bias, cache_seqlens=lens)
         torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
 
 


### PR DESCRIPTION
…ate row max during masked operations, preventing NaN issues and ensuring proper scaling in attention mechanisms